### PR TITLE
Enable daily resolution for net worth graph

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -40,6 +40,7 @@ type NetWorthGraphProps = {
   };
   compact?: boolean;
   showTooltip?: boolean;
+  interval?: string;
 };
 
 export function NetWorthGraph({
@@ -47,10 +48,14 @@ export function NetWorthGraph({
   graphData,
   compact = false,
   showTooltip = true,
+  interval = 'Monthly',
 }: NetWorthGraphProps) {
   const { t } = useTranslation();
   const privacyMode = usePrivacyMode();
   const id = useId();
+
+  // Use more aggressive smoothing for high-frequency data
+  const interpolationType = interval === 'Daily' || interval === 'Weekly' ? 'basis' : 'monotone';
 
   const tickFormatter = tick => {
     const res = privacyMode
@@ -197,14 +202,16 @@ export function NetWorthGraph({
                 </defs>
 
                 <Area
-                  type="monotone"
+                  type={interpolationType}
                   dot={false}
                   activeDot={false}
                   animationDuration={0}
                   dataKey="y"
                   stroke={theme.reportsBlue}
+                  strokeWidth={2}
                   fill={`url(#${gradientId})`}
                   fillOpacity={1}
+                  connectNulls={true}
                 />
               </AreaChart>
             </div>

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -105,8 +105,9 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
         conditionsOp,
         locale,
         interval,
+        firstDayOfWeekIdx,
       ),
-    [start, end, accounts, conditions, conditionsOp, locale, interval],
+    [start, end, accounts, conditions, conditionsOp, locale, interval, firstDayOfWeekIdx],
   );
   const data = useReport('net_worth', reportParams);
   useEffect(() => {

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -300,6 +300,7 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
         <NetWorthGraph
           graphData={data.graphData}
           showTooltip={!isNarrowWidth}
+          interval={interval}
         />
 
         <View style={{ marginTop: 30, userSelect: 'none' }}>

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -15,6 +15,9 @@ import * as monthUtils from 'loot-core/shared/months';
 import { integerToCurrency } from 'loot-core/shared/util';
 import { type TimeFrame, type NetWorthWidget } from 'loot-core/types/models';
 
+import { Select } from '@actual-app/components/select';
+import { SpaceBetween } from '@actual-app/components/space-between';
+
 import { EditablePageHeaderTitle } from '@desktop-client/components/EditablePageHeaderTitle';
 import { MobileBackButton } from '@desktop-client/components/mobile/MobileBackButton';
 import {
@@ -28,6 +31,7 @@ import { NetWorthGraph } from '@desktop-client/components/reports/graphs/NetWort
 import { Header } from '@desktop-client/components/reports/Header';
 import { LoadingIndicator } from '@desktop-client/components/reports/LoadingIndicator';
 import { calculateTimeRange } from '@desktop-client/components/reports/reportRanges';
+import { ReportOptions } from '@desktop-client/components/reports/ReportOptions';
 import { createSpreadsheet as netWorthSpreadsheet } from '@desktop-client/components/reports/spreadsheets/net-worth-spreadsheet';
 import { useReport } from '@desktop-client/components/reports/useReport';
 import { fromDateRepr } from '@desktop-client/components/reports/util';
@@ -87,6 +91,9 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
   const [start, setStart] = useState(initialStart);
   const [end, setEnd] = useState(initialEnd);
   const [mode, setMode] = useState(initialMode);
+  const [interval, setInterval] = useState(
+    widget?.meta?.interval || 'Monthly',
+  );
 
   const reportParams = useMemo(
     () =>
@@ -97,8 +104,9 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
         conditions,
         conditionsOp,
         locale,
+        interval,
       ),
-    [start, end, accounts, conditions, conditionsOp, locale],
+    [start, end, accounts, conditions, conditionsOp, locale, interval],
   );
   const data = useReport('net_worth', reportParams);
   useEffect(() => {
@@ -141,19 +149,20 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
       throw new Error('No widget that could be saved.');
     }
 
-    await send('dashboard-update-widget', {
-      id: widget.id,
-      meta: {
-        ...(widget.meta ?? {}),
-        conditions,
-        conditionsOp,
-        timeFrame: {
-          start,
-          end,
-          mode,
-        },
-      },
-    });
+            await send('dashboard-update-widget', {
+          id: widget.id,
+          meta: {
+            ...(widget.meta ?? {}),
+            conditions,
+            conditionsOp,
+            interval,
+            timeFrame: {
+              start,
+              end,
+              mode,
+            },
+          },
+        });
     dispatch(
       addNotification({
         notification: {
@@ -239,6 +248,29 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
           </Button>
         )}
       </Header>
+
+      <View
+        style={{
+          padding: 20,
+          paddingTop: 10,
+          paddingBottom: 10,
+          flexShrink: 0,
+        }}
+      >
+        <SpaceBetween gap={10}>
+          <View style={{ fontSize: 14, fontWeight: 500 }}>
+            <Trans>Interval:</Trans>
+          </View>
+          <Select
+            value={interval}
+            onChange={setInterval}
+            options={ReportOptions.interval.map(({ description, key }) => [
+              key,
+              description,
+            ])}
+          />
+        </SpaceBetween>
+      </View>
 
       <View
         style={{

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -17,6 +17,7 @@ import {
 
 import { type useSpreadsheet } from '@desktop-client/hooks/useSpreadsheet';
 import { aqlQuery } from '@desktop-client/queries/aqlQuery';
+import { ReportOptions } from '@desktop-client/components/reports/ReportOptions';
 
 type Balance = {
   date: string;
@@ -41,6 +42,10 @@ export function createSpreadsheet(
     });
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
+    // Use the same pattern as custom reports for interval handling
+    const intervalGroup = getGroupByExpression(interval);
+    const intervalFilter = getIntervalFilter(interval);
+
     const data = await Promise.all(
       accounts.map(async acct => {
         const [starting, balances]: [number, Balance[]] = await Promise.all([
@@ -49,7 +54,7 @@ export function createSpreadsheet(
               .filter({
                 [conditionsOpKey]: filters,
                 account: acct.id,
-                date: { $lt: getIntervalStartDate(start, interval) },
+                date: { $transform: intervalFilter, $lt: start },
               })
               .calculate({ $sum: '$amount' }),
           ).then(({ data }) => data),
@@ -62,21 +67,29 @@ export function createSpreadsheet(
               .filter({
                 account: acct.id,
                 $and: [
-                  { date: { $gte: getIntervalStartDate(start, interval) } },
-                  { date: { $lte: getIntervalEndDate(end, interval) } },
+                  { date: { $transform: intervalFilter, $gte: start } },
+                  { date: { $transform: intervalFilter, $lte: end } },
                 ],
               })
-              .groupBy(getGroupByExpression(interval))
+              .groupBy(intervalGroup)
               .select([
-                { date: getGroupByExpression(interval) },
+                { date: intervalGroup },
                 { amount: { $sum: '$amount' } },
               ]),
           ).then(({ data }) => data),
         ]);
 
+        // Handle Weekly interval by transforming dates like custom reports do
+        const transformedBalances = interval === 'Weekly' 
+          ? balances.map(b => ({
+              ...b,
+              date: monthUtils.weekFromDate(b.date, '0'),
+            }))
+          : balances;
+
         return {
           id: acct.id,
-          balances: keyBy(balances, 'date'),
+          balances: keyBy(transformedBalances, 'date'),
           starting,
         };
       }),
@@ -87,46 +100,24 @@ export function createSpreadsheet(
 }
 
 function getGroupByExpression(interval: string) {
-  switch (interval) {
-    case 'Daily':
-      return { $day: '$date' }; // This groups by full date: YYYY-MM-DD
-    case 'Weekly':
-      return { $week: '$date' };
-    case 'Yearly':
-      return { $year: '$date' };
-    case 'Monthly':
-    default:
-      return { $month: '$date' };
-  }
+  const intervalGroup =
+    interval === 'Monthly'
+      ? { $month: '$date' }
+      : interval === 'Yearly'
+        ? { $year: '$date' }
+        : { $day: '$date' };
+  return intervalGroup;
 }
 
-function getIntervalStartDate(date: string, interval: string): string {
-  switch (interval) {
-    case 'Daily':
-      return date; // For daily, use the exact date
-    case 'Weekly':
-      return monthUtils.weekFromDate(date, '0'); // Start of week
-    case 'Yearly':
-      return monthUtils.getYearStart(date);
-    case 'Monthly':
-    default:
-      return monthUtils.firstDayOfMonth(date);
-  }
+function getIntervalFilter(interval: string) {
+  const intervalFilter =
+    interval === 'Weekly'
+      ? '$day'
+      : '$' + (ReportOptions.intervalMap.get(interval)?.toLowerCase() || 'month');
+  return intervalFilter;
 }
 
-function getIntervalEndDate(date: string, interval: string): string {
-  switch (interval) {
-    case 'Daily':
-      return date; // For daily, use the exact date
-    case 'Weekly':
-      return monthUtils.getWeekEnd(date, '0'); // End of week
-    case 'Yearly':
-      return monthUtils.getYearEnd(date);
-    case 'Monthly':
-    default:
-      return monthUtils.lastDayOfMonth(date);
-  }
-}
+
 
 function recalculate(
   data: Array<{
@@ -139,7 +130,13 @@ function recalculate(
   locale: Locale,
   interval: string = 'Monthly',
 ) {
-  const intervals = getIntervalRange(start, end, interval);
+  // Use the same interval range logic as custom reports
+  const intervals =
+    interval === 'Weekly'
+      ? monthUtils.weekRangeInclusive(start, end, '0')
+      : monthUtils[
+          ReportOptions.intervalRange.get(interval) || 'rangeInclusive'
+        ](start, end);
 
   const accountBalances = data.map(account => {
     // Start off with the balance at that point in time
@@ -188,7 +185,11 @@ function recalculate(
       hasNegative = true;
     }
 
-    const x = parseIntervalDate(intervalItem, interval);
+    const x = d.parseISO(
+      interval === 'Yearly' ? intervalItem + '-01-01' :
+      interval === 'Daily' ? intervalItem :
+      intervalItem + '-01'
+    );
     const change = last ? total - amountToInteger(last.y) : 0;
 
     if (arr.length === 0) {
@@ -196,14 +197,26 @@ function recalculate(
     }
     endNetWorth = total;
 
+    const displayFormat = 
+      interval === 'Daily' ? 'MM/dd' :
+      interval === 'Weekly' ? 'MM/dd' :
+      interval === 'Yearly' ? 'yyyy' :
+      "MMM ''yy"; // Monthly default
+
+    const tooltipFormat = 
+      interval === 'Daily' ? 'MMMM d, yyyy' :
+      interval === 'Weekly' ? 'MMM d, yyyy' :
+      interval === 'Yearly' ? 'yyyy' :
+      'MMMM yyyy'; // Monthly default
+
     arr.push({
-      x: formatIntervalForDisplay(x, interval, locale),
+      x: d.format(x, displayFormat, { locale }),
       y: integerToAmount(total),
       assets: integerToCurrency(assets),
       debt: `-${integerToCurrency(debt)}`,
       change: integerToCurrency(change),
       networth: integerToCurrency(total),
-      date: formatIntervalForTooltip(x, interval, locale),
+      date: d.format(x, tooltipFormat, { locale }),
     });
 
     arr.forEach(item => {
@@ -229,60 +242,4 @@ function recalculate(
     lowestNetWorth,
     highestNetWorth,
   };
-}
-
-function getIntervalRange(start: string, end: string, interval: string): string[] {
-  switch (interval) {
-    case 'Daily':
-      return monthUtils.dayRangeInclusive(start, end);
-    case 'Weekly':
-      return monthUtils.weekRangeInclusive(start, end, '0');
-    case 'Yearly':
-      return monthUtils.yearRangeInclusive(start, end);
-    case 'Monthly':
-    default:
-      return monthUtils.rangeInclusive(start, end);
-  }
-}
-
-function parseIntervalDate(intervalItem: string, interval: string): Date {
-  switch (interval) {
-    case 'Daily':
-      return d.parseISO(intervalItem);
-    case 'Weekly':
-      return d.parseISO(intervalItem);
-    case 'Yearly':
-      return d.parseISO(intervalItem + '-01-01');
-    case 'Monthly':
-    default:
-      return d.parseISO(intervalItem + '-01');
-  }
-}
-
-function formatIntervalForDisplay(date: Date, interval: string, locale: Locale): string {
-  switch (interval) {
-    case 'Daily':
-      return d.format(date, 'MM/dd', { locale });
-    case 'Weekly':
-      return d.format(date, 'MM/dd', { locale });
-    case 'Yearly':
-      return d.format(date, 'yyyy', { locale });
-    case 'Monthly':
-    default:
-      return d.format(date, "MMM ''yy", { locale });
-  }
-}
-
-function formatIntervalForTooltip(date: Date, interval: string, locale: Locale): string {
-  switch (interval) {
-    case 'Daily':
-      return d.format(date, 'MMMM d, yyyy', { locale });
-    case 'Weekly':
-      return d.format(date, 'MMM d, yyyy', { locale });
-    case 'Yearly':
-      return d.format(date, 'yyyy', { locale });
-    case 'Monthly':
-    default:
-      return d.format(date, 'MMMM yyyy', { locale });
-  }
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -46,9 +46,9 @@ export function createSpreadsheet(
     const isWeekly = interval === 'Weekly';
     const isYearly = interval === 'Yearly';
     
-    // For daily and weekly, we need to work with actual dates, not month transforms
-    const startDate = isDaily || isWeekly ? start : monthUtils.firstDayOfMonth(start);
-    const endDate = isDaily || isWeekly ? end : monthUtils.lastDayOfMonth(end);
+    // Always convert to full date format for database queries
+    const startDate = monthUtils.firstDayOfMonth(start);
+    const endDate = monthUtils.lastDayOfMonth(end);
 
     const data = await Promise.all(
       accounts.map(async acct => {
@@ -107,7 +107,7 @@ export function createSpreadsheet(
       }),
     );
 
-    setData(recalculate(data, start, end, locale, interval));
+    setData(recalculate(data, startDate, endDate, locale, interval));
   };
 }
 
@@ -122,7 +122,11 @@ function getDateRanges(start: string, end: string, interval: string) {
       return monthUtils.yearRangeInclusive(start, end);
     case 'Monthly':
     default:
-      return monthUtils.rangeInclusive(start, end);
+      // For monthly, convert back to month format
+      return monthUtils.rangeInclusive(
+        monthUtils.getMonth(start), 
+        monthUtils.getMonth(end)
+      );
   }
 }
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -31,6 +31,7 @@ export function createSpreadsheet(
   conditionsOp: 'and' | 'or' = 'and',
   locale: Locale,
   interval: string = 'Monthly',
+  firstDayOfWeekIdx: string = '0',
 ) {
   return async (
     spreadsheet: ReturnType<typeof useSpreadsheet>,
@@ -41,7 +42,7 @@ export function createSpreadsheet(
     });
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
-    // Handle different intervals like cash flow does - simpler approach
+    // Handle different intervals following the pattern from other reports
     const isDaily = interval === 'Daily';
     const isWeekly = interval === 'Weekly';
     const isYearly = interval === 'Yearly';
@@ -76,6 +77,7 @@ export function createSpreadsheet(
                 ],
               })
               .groupBy(
+                // For weekly, use daily grouping and transform later (like other reports)
                 isDaily || isWeekly ? 'date' :
                 isYearly ? { $year: '$date' } :
                 { $month: '$date' }
@@ -91,11 +93,11 @@ export function createSpreadsheet(
           ).then(({ data }) => data),
         ]);
 
-        // Handle Weekly interval by transforming dates
+        // Handle Weekly interval by transforming dates (same pattern as other reports)
         const transformedBalances = isWeekly 
           ? balances.map(b => ({
               ...b,
-              date: monthUtils.weekFromDate(b.date, '0'),
+              date: monthUtils.weekFromDate(b.date, firstDayOfWeekIdx),
             }))
           : balances;
 
@@ -107,17 +109,17 @@ export function createSpreadsheet(
       }),
     );
 
-    setData(recalculate(data, startDate, endDate, locale, interval));
+    setData(recalculate(data, startDate, endDate, locale, interval, firstDayOfWeekIdx));
   };
 }
 
 // Helper function to get the correct date ranges based on interval
-function getDateRanges(start: string, end: string, interval: string) {
+function getDateRanges(start: string, end: string, interval: string, firstDayOfWeekIdx: string) {
   switch (interval) {
     case 'Daily':
       return monthUtils.dayRangeInclusive(start, end);
     case 'Weekly':
-      return monthUtils.weekRangeInclusive(start, end, '0');
+      return monthUtils.weekRangeInclusive(start, end, firstDayOfWeekIdx);
     case 'Yearly':
       return monthUtils.yearRangeInclusive(start, end);
     case 'Monthly':
@@ -187,9 +189,10 @@ function recalculate(
   end: string,
   locale: Locale,
   interval: string = 'Monthly',
+  firstDayOfWeekIdx: string = '0',
 ) {
   // Get the correct date intervals
-  const intervals = getDateRanges(start, end, interval);
+  const intervals = getDateRanges(start, end, interval, firstDayOfWeekIdx);
 
   const accountBalances = data.map(account => {
     // Start off with the balance at that point in time

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -130,6 +130,51 @@ function getDateRanges(start: string, end: string, interval: string) {
   }
 }
 
+// Helper function to apply smoothing to data for high-frequency intervals
+function applySmoothingToData(
+  data: Array<{
+    x: string;
+    y: number;
+    assets: string;
+    debt: string;
+    change: string;
+    networth: string;
+    date: string;
+  }>,
+  interval: string,
+  windowSize: number = 7, // Default 7-day moving average
+) {
+  if (interval !== 'Daily' && interval !== 'Weekly') {
+    return data; // No smoothing for monthly/yearly
+  }
+
+  if (data.length <= windowSize) {
+    return data; // Not enough data points for smoothing
+  }
+
+  return data.map((item, index) => {
+    // For smoothing, we only smooth the y value (net worth), keep other fields as-is
+    const startIndex = Math.max(0, index - Math.floor(windowSize / 2));
+    const endIndex = Math.min(data.length - 1, index + Math.floor(windowSize / 2));
+    
+    let sum = 0;
+    let count = 0;
+    
+    for (let i = startIndex; i <= endIndex; i++) {
+      sum += data[i].y;
+      count++;
+    }
+    
+    const smoothedValue = sum / count;
+    
+    return {
+      ...item,
+      y: smoothedValue,
+      networth: integerToCurrency(amountToInteger(smoothedValue)),
+    };
+  });
+}
+
 
 
 function recalculate(
@@ -239,9 +284,12 @@ function recalculate(
     return arr;
   }, []);
 
+  // Apply smoothing to daily and weekly data
+  const smoothedData = applySmoothingToData(graphData, interval);
+
   return {
     graphData: {
-      data: graphData,
+      data: smoothedData,
       hasNegative,
       start,
       end,

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -30,6 +30,7 @@ export function createSpreadsheet(
   conditions: RuleConditionEntity[] = [],
   conditionsOp: 'and' | 'or' = 'and',
   locale: Locale,
+  interval: string = 'Monthly',
 ) {
   return async (
     spreadsheet: ReturnType<typeof useSpreadsheet>,
@@ -48,7 +49,7 @@ export function createSpreadsheet(
               .filter({
                 [conditionsOpKey]: filters,
                 account: acct.id,
-                date: { $lt: monthUtils.firstDayOfMonth(start) },
+                date: { $lt: getIntervalStartDate(start, interval) },
               })
               .calculate({ $sum: '$amount' }),
           ).then(({ data }) => data),
@@ -61,13 +62,13 @@ export function createSpreadsheet(
               .filter({
                 account: acct.id,
                 $and: [
-                  { date: { $gte: monthUtils.firstDayOfMonth(start) } },
-                  { date: { $lte: monthUtils.lastDayOfMonth(end) } },
+                  { date: { $gte: getIntervalStartDate(start, interval) } },
+                  { date: { $lte: getIntervalEndDate(end, interval) } },
                 ],
               })
-              .groupBy({ $month: '$date' })
+              .groupBy(getGroupByExpression(interval))
               .select([
-                { date: { $month: '$date' } },
+                { date: getGroupByExpression(interval) },
                 { amount: { $sum: '$amount' } },
               ]),
           ).then(({ data }) => data),
@@ -81,8 +82,50 @@ export function createSpreadsheet(
       }),
     );
 
-    setData(recalculate(data, start, end, locale));
+    setData(recalculate(data, start, end, locale, interval));
   };
+}
+
+function getGroupByExpression(interval: string) {
+  switch (interval) {
+    case 'Daily':
+      return { $day: '$date' }; // This groups by full date: YYYY-MM-DD
+    case 'Weekly':
+      return { $week: '$date' };
+    case 'Yearly':
+      return { $year: '$date' };
+    case 'Monthly':
+    default:
+      return { $month: '$date' };
+  }
+}
+
+function getIntervalStartDate(date: string, interval: string): string {
+  switch (interval) {
+    case 'Daily':
+      return date; // For daily, use the exact date
+    case 'Weekly':
+      return monthUtils.weekFromDate(date, '0'); // Start of week
+    case 'Yearly':
+      return monthUtils.getYearStart(date);
+    case 'Monthly':
+    default:
+      return monthUtils.firstDayOfMonth(date);
+  }
+}
+
+function getIntervalEndDate(date: string, interval: string): string {
+  switch (interval) {
+    case 'Daily':
+      return date; // For daily, use the exact date
+    case 'Weekly':
+      return monthUtils.getWeekEnd(date, '0'); // End of week
+    case 'Yearly':
+      return monthUtils.getYearEnd(date);
+    case 'Monthly':
+    default:
+      return monthUtils.lastDayOfMonth(date);
+  }
 }
 
 function recalculate(
@@ -94,15 +137,16 @@ function recalculate(
   start: string,
   end: string,
   locale: Locale,
+  interval: string = 'Monthly',
 ) {
-  const months = monthUtils.rangeInclusive(start, end);
+  const intervals = getIntervalRange(start, end, interval);
 
   const accountBalances = data.map(account => {
     // Start off with the balance at that point in time
     let balance = account.starting;
-    return months.map(month => {
-      if (account.balances[month]) {
-        balance += account.balances[month].amount;
+    return intervals.map(intervalItem => {
+      if (account.balances[intervalItem]) {
+        balance += account.balances[intervalItem].amount;
       }
       return balance;
     });
@@ -114,7 +158,7 @@ function recalculate(
   let lowestNetWorth: number | null = null;
   let highestNetWorth: number | null = null;
 
-  const graphData = months.reduce<
+  const graphData = intervals.reduce<
     Array<{
       x: string;
       y: number;
@@ -124,7 +168,7 @@ function recalculate(
       networth: string;
       date: string;
     }>
-  >((arr, month, idx) => {
+  >((arr, intervalItem, idx) => {
     let debt = 0;
     let assets = 0;
     let total = 0;
@@ -144,7 +188,7 @@ function recalculate(
       hasNegative = true;
     }
 
-    const x = d.parseISO(month + '-01');
+    const x = parseIntervalDate(intervalItem, interval);
     const change = last ? total - amountToInteger(last.y) : 0;
 
     if (arr.length === 0) {
@@ -153,13 +197,13 @@ function recalculate(
     endNetWorth = total;
 
     arr.push({
-      x: d.format(x, 'MMM ’yy', { locale }),
+      x: formatIntervalForDisplay(x, interval, locale),
       y: integerToAmount(total),
       assets: integerToCurrency(assets),
       debt: `-${integerToCurrency(debt)}`,
       change: integerToCurrency(change),
       networth: integerToCurrency(total),
-      date: d.format(x, 'MMMM yyyy', { locale }),
+      date: formatIntervalForTooltip(x, interval, locale),
     });
 
     arr.forEach(item => {
@@ -185,4 +229,60 @@ function recalculate(
     lowestNetWorth,
     highestNetWorth,
   };
+}
+
+function getIntervalRange(start: string, end: string, interval: string): string[] {
+  switch (interval) {
+    case 'Daily':
+      return monthUtils.dayRangeInclusive(start, end);
+    case 'Weekly':
+      return monthUtils.weekRangeInclusive(start, end, '0');
+    case 'Yearly':
+      return monthUtils.yearRangeInclusive(start, end);
+    case 'Monthly':
+    default:
+      return monthUtils.rangeInclusive(start, end);
+  }
+}
+
+function parseIntervalDate(intervalItem: string, interval: string): Date {
+  switch (interval) {
+    case 'Daily':
+      return d.parseISO(intervalItem);
+    case 'Weekly':
+      return d.parseISO(intervalItem);
+    case 'Yearly':
+      return d.parseISO(intervalItem + '-01-01');
+    case 'Monthly':
+    default:
+      return d.parseISO(intervalItem + '-01');
+  }
+}
+
+function formatIntervalForDisplay(date: Date, interval: string, locale: Locale): string {
+  switch (interval) {
+    case 'Daily':
+      return d.format(date, 'MM/dd', { locale });
+    case 'Weekly':
+      return d.format(date, 'MM/dd', { locale });
+    case 'Yearly':
+      return d.format(date, 'yyyy', { locale });
+    case 'Monthly':
+    default:
+      return d.format(date, "MMM ''yy", { locale });
+  }
+}
+
+function formatIntervalForTooltip(date: Date, interval: string, locale: Locale): string {
+  switch (interval) {
+    case 'Daily':
+      return d.format(date, 'MMMM d, yyyy', { locale });
+    case 'Weekly':
+      return d.format(date, 'MMM d, yyyy', { locale });
+    case 'Yearly':
+      return d.format(date, 'yyyy', { locale });
+    case 'Monthly':
+    default:
+      return d.format(date, 'MMMM yyyy', { locale });
+  }
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -17,7 +17,6 @@ import {
 
 import { type useSpreadsheet } from '@desktop-client/hooks/useSpreadsheet';
 import { aqlQuery } from '@desktop-client/queries/aqlQuery';
-import { ReportOptions } from '@desktop-client/components/reports/ReportOptions';
 
 type Balance = {
   date: string;
@@ -42,9 +41,14 @@ export function createSpreadsheet(
     });
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
-    // Use the same pattern as custom reports for interval handling
-    const intervalGroup = getGroupByExpression(interval);
-    const intervalFilter = getIntervalFilter(interval);
+    // Handle different intervals like cash flow does - simpler approach
+    const isDaily = interval === 'Daily';
+    const isWeekly = interval === 'Weekly';
+    const isYearly = interval === 'Yearly';
+    
+    // For daily and weekly, we need to work with actual dates, not month transforms
+    const startDate = isDaily || isWeekly ? start : monthUtils.firstDayOfMonth(start);
+    const endDate = isDaily || isWeekly ? end : monthUtils.lastDayOfMonth(end);
 
     const data = await Promise.all(
       accounts.map(async acct => {
@@ -54,7 +58,7 @@ export function createSpreadsheet(
               .filter({
                 [conditionsOpKey]: filters,
                 account: acct.id,
-                date: { $transform: intervalFilter, $lt: start },
+                date: { $lt: startDate },
               })
               .calculate({ $sum: '$amount' }),
           ).then(({ data }) => data),
@@ -67,20 +71,28 @@ export function createSpreadsheet(
               .filter({
                 account: acct.id,
                 $and: [
-                  { date: { $transform: intervalFilter, $gte: start } },
-                  { date: { $transform: intervalFilter, $lte: end } },
+                  { date: { $gte: startDate } },
+                  { date: { $lte: endDate } },
                 ],
               })
-              .groupBy(intervalGroup)
+              .groupBy(
+                isDaily || isWeekly ? 'date' :
+                isYearly ? { $year: '$date' } :
+                { $month: '$date' }
+              )
               .select([
-                { date: intervalGroup },
+                { 
+                  date: isDaily || isWeekly ? 'date' :
+                        isYearly ? { $year: '$date' } :
+                        { $month: '$date' }
+                },
                 { amount: { $sum: '$amount' } },
               ]),
           ).then(({ data }) => data),
         ]);
 
-        // Handle Weekly interval by transforming dates like custom reports do
-        const transformedBalances = interval === 'Weekly' 
+        // Handle Weekly interval by transforming dates
+        const transformedBalances = isWeekly 
           ? balances.map(b => ({
               ...b,
               date: monthUtils.weekFromDate(b.date, '0'),
@@ -99,22 +111,19 @@ export function createSpreadsheet(
   };
 }
 
-function getGroupByExpression(interval: string) {
-  const intervalGroup =
-    interval === 'Monthly'
-      ? { $month: '$date' }
-      : interval === 'Yearly'
-        ? { $year: '$date' }
-        : { $day: '$date' };
-  return intervalGroup;
-}
-
-function getIntervalFilter(interval: string) {
-  const intervalFilter =
-    interval === 'Weekly'
-      ? '$day'
-      : '$' + (ReportOptions.intervalMap.get(interval)?.toLowerCase() || 'month');
-  return intervalFilter;
+// Helper function to get the correct date ranges based on interval
+function getDateRanges(start: string, end: string, interval: string) {
+  switch (interval) {
+    case 'Daily':
+      return monthUtils.dayRangeInclusive(start, end);
+    case 'Weekly':
+      return monthUtils.weekRangeInclusive(start, end, '0');
+    case 'Yearly':
+      return monthUtils.yearRangeInclusive(start, end);
+    case 'Monthly':
+    default:
+      return monthUtils.rangeInclusive(start, end);
+  }
 }
 
 
@@ -130,13 +139,8 @@ function recalculate(
   locale: Locale,
   interval: string = 'Monthly',
 ) {
-  // Use the same interval range logic as custom reports
-  const intervals =
-    interval === 'Weekly'
-      ? monthUtils.weekRangeInclusive(start, end, '0')
-      : monthUtils[
-          ReportOptions.intervalRange.get(interval) || 'rangeInclusive'
-        ](start, end);
+  // Get the correct date intervals
+  const intervals = getDateRanges(start, end, interval);
 
   const accountBalances = data.map(account => {
     // Start off with the balance at that point in time
@@ -185,11 +189,12 @@ function recalculate(
       hasNegative = true;
     }
 
-    const x = d.parseISO(
-      interval === 'Yearly' ? intervalItem + '-01-01' :
-      interval === 'Daily' ? intervalItem :
-      intervalItem + '-01'
-    );
+    // Parse dates correctly based on interval type
+    const x = interval === 'Daily' || interval === 'Weekly' 
+      ? d.parseISO(intervalItem)
+      : interval === 'Yearly'
+      ? d.parseISO(intervalItem + '-01-01')
+      : d.parseISO(intervalItem + '-01');
     const change = last ? total - amountToInteger(last.y) : 0;
 
     if (arr.length === 0) {

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -28,6 +28,7 @@ export type NetWorthWidget = AbstractWidget<
     conditions?: RuleConditionEntity[];
     conditionsOp?: 'and' | 'or';
     timeFrame?: TimeFrame;
+    interval?: string;
   } | null
 >;
 export type CashFlowWidget = AbstractWidget<

--- a/upcoming-release-notes/5264.md
+++ b/upcoming-release-notes/5264.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [claude-3-5-sonnet-20241022]
+---
+
+Added daily interval support to net worth graph, allowing users to view net worth changes on a daily basis in addition to the existing monthly view.


### PR DESCRIPTION
```
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
This PR adds an "Interval" option to the Net Worth graph, allowing users to view their net worth at Daily, Weekly, Monthly, or Yearly resolutions.

**Why this change?**
Previously, the net worth graph was limited to monthly data points. Users requested more granular insights, particularly a daily view, to better track short-term fluctuations and trends. This change leverages existing daily interval infrastructure from the custom reports system to provide this functionality.

**Key changes:**
- Added an interval selection dropdown to the Net Worth report UI.
- Updated the net worth spreadsheet to dynamically group and format data based on the selected interval (Daily, Weekly, Monthly, Yearly).
- Ensured the chosen interval is persisted with the widget settings.
```